### PR TITLE
deps: update dialoguer to v0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.26"
 tokio = { version = "1.25.0", features = ["full"] }
 rand = { version = "0.8.5", features = ["std_rng"] }
 console = "0.15.5"
-dialoguer = "0.10.4"
+dialoguer = "0.11.0"
 
 [lib]
 name = "tracing_indicatif"


### PR DESCRIPTION
I'm packaging this project for Fedora Linux as a dependency of [ruff](https://github.com/astral-sh/ruff) and noticed that one of the dev-dependencies is currently outdated. This PR bumps dialoguer to the latest version, and it does not appear to require code changes, and the example that uses dialoguer still seems to work as expected.