### PR TITLE
feat: allow to manually finish progressbar

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,9 +296,15 @@ impl IndicatifSpanContext {
         }
     }
 
-    fn progress_bar_tick(&mut self) {
+    fn progress_bar_tick(&self) {
         if let Some(ref pb) = self.progress_bar {
             pb.tick()
+        }
+    }
+
+    fn progress_bar_finish_clear(&self) {
+        if let Some(ref pb) = self.progress_bar {
+            pb.finish_and_clear();
         }
     }
 }

--- a/src/pb_manager.rs
+++ b/src/pb_manager.rs
@@ -149,7 +149,7 @@ impl ProgressBarManager {
         self.tick_settings = tick_settings;
     }
 
-    fn decrement_pending_pb(&mut self) {
+    fn decrement_pending_pb(&self) {
         let prev_val = self
             .pending_progress_bars
             .fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
@@ -262,6 +262,12 @@ impl ProgressBarManager {
 
         // The span closed before we had a chance to show its progress bar.
         if pb.is_hidden() {
+            self.decrement_pending_pb();
+            return;
+        }
+
+        // PorgressBar is already finished
+        if pb.is_finished() {
             self.decrement_pending_pb();
             return;
         }

--- a/src/span_ext.rs
+++ b/src/span_ext.rs
@@ -76,6 +76,9 @@ pub trait IndicatifSpanExt {
     ///
     /// Has no effect if the progress bar for this span is not active.
     fn pb_tick(&self);
+
+    /// Finish the progress bar
+    fn pb_finish_clear(&self);
 }
 
 impl IndicatifSpanExt for Span {
@@ -123,6 +126,12 @@ impl IndicatifSpanExt for Span {
     fn pb_tick(&self) {
         apply_to_indicatif_span(self, |indicatif_ctx| {
             indicatif_ctx.progress_bar_tick();
+        });
+    }
+
+    fn pb_finish_clear(&self) {
+        apply_to_indicatif_span(self, |indicatif_ctx| {
+            indicatif_ctx.progress_bar_finish_clear();
         });
     }
 }


### PR DESCRIPTION
this is originally a workaround for the deadlock found in issue #10

also removed some unused &mut ref