### PR TITLE
Update to indicatif 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/tracing-indicatif"
 exclude = ["*.gif"]
 
 [dependencies]
-indicatif = { version = "0.17.9", features = ["in_memory"] }
+indicatif = { version = "0.18.0", features = ["in_memory"] }
 tracing = "0.1.40"
 tracing-core = "0.1.32"
 tracing-subscriber = { version = "0.3.18" }
@@ -20,7 +20,6 @@ tracing-subscriber = { version = "0.3.18" }
 futures = "0.3.31"
 tokio = { version = "1.41.1", features = ["full"] }
 rand = { version = "0.8.5", features = ["std_rng"] }
-console = "0.15.8"
 dialoguer = "0.11.0"
 
 [lib]


### PR DESCRIPTION
This is required for using [`IndicatifSpanExt::pb_set_style`](https://docs.rs/tracing-indicatif/0.3.9/tracing_indicatif/span_ext/trait.IndicatifSpanExt.html#tymethod.pb_set_style) with indicatif 0.18's `ProgressStyle` type as opposed to indicatif 0.17's, fixing errors like this one when a crate uses the most recent release of indicatif:

```console
error[E0308]: mismatched types
   --> src/main.rs:382:23
    |
382 |     span.pb_set_style(&pb_style);
    |          ------------ ^^^^^^^^^ expected `tracing_indicatif::style::ProgressStyle`, found `indicatif::ProgressStyle`
    |          |
    |          arguments to this method are incorrect
    |
note: two different versions of crate `indicatif` are being used; two types coming from two different versions of the same crate are different types even if they look the same
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/indicatif-0.17.11/src/style.rs:21:1
    |
21  | pub struct ProgressStyle {
    | ^^^^^^^^^^^^^^^^^^^^^^^^ this is the expected type `tracing_indicatif::style::ProgressStyle`
    |
   ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/indicatif-0.18.0/src/style.rs:21:1
    |
21  | pub struct ProgressStyle {
    | ^^^^^^^^^^^^^^^^^^^^^^^^ this is the found type `indicatif::ProgressStyle`
    |
   ::: src/main.rs:18:5
    |
18  | use indicatif::ProgressStyle;
    |     --------- one version of crate `indicatif` used here, as a direct dependency of the current crate
...
35  | use tracing_indicatif::span_ext::IndicatifSpanExt;
    |     ----------------- one version of crate `indicatif` used here, as a dependency of crate `tracing_indicatif`
    = help: you can use `cargo tree` to explore your dependency tree
note: method defined here
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-indicatif-0.3.9/src/span_ext.rs:39:8
    |
39  |     fn pb_set_style(&self, style: &ProgressStyle);
    |        ^^^^^^^^^^^^
```