### PR TITLE
Allow progress bar to finish with message

### DIFF
--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -40,8 +40,10 @@ async fn main() {
         .init();
 
     let header_span = info_span!("header");
-    header_span.pb_set_style(&ProgressStyle::default_bar());
+    header_span.pb_set_style(&ProgressStyle::with_template("{wide_bar} {pos}/{len} {msg}").unwrap());
     header_span.pb_set_length(20);
+    header_span.pb_set_message("Processing items");
+    header_span.pb_set_finish_message("All items processed");
 
     let header_span_enter = header_span.enter();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,8 @@ struct IndicatifSpanContext {
     // Used to quickly compute a child span's prefix without having to traverse up the entire span
     // scope.
     level: u16,
+    // If `Some`, this is the message that will be displayed when the progress bar is finished.
+    finish_message: Option<String>,
 }
 
 impl IndicatifSpanContext {
@@ -318,6 +320,10 @@ impl IndicatifSpanContext {
         if let Some(ref pb) = self.progress_bar {
             pb.reset_eta();
         }
+    }
+
+    fn set_progress_bar_finish_message(&mut self, msg: String) {
+        self.finish_message = Some(msg);
     }
 }
 
@@ -685,6 +691,7 @@ where
             span_name: span.name().to_string(),
             span_child_prefix,
             level,
+            finish_message: None,
         });
     }
 

--- a/src/pb_manager.rs
+++ b/src/pb_manager.rs
@@ -267,8 +267,12 @@ impl ProgressBarManager {
         }
 
         // This span had an active/shown progress bar.
-        pb.finish_and_clear();
-        self.mp.remove(&pb);
+        if let Some(finish_message) = pb_span_ctx.finish_message.take() {
+            pb.finish_with_message(finish_message);
+        } else {
+            pb.finish_and_clear();
+            self.mp.remove(&pb);
+        }
         self.active_progress_bars -= 1;
 
         loop {

--- a/src/span_ext.rs
+++ b/src/span_ext.rs
@@ -85,6 +85,12 @@ pub trait IndicatifSpanExt {
 
     /// Resets the eta of the progress bar for this span.
     fn pb_reset_eta(&self);
+
+    /// Sets message of the progress bar that would be displayed when the span is finished.
+    ///
+    /// See also [`finish_with_message`](indicatif::ProgressBar::finish_with_message).
+    /// If unset, the progress bar will be removed when the span is finished.
+    fn pb_set_finish_message(&self, msg: &str);
 }
 
 impl IndicatifSpanExt for Span {
@@ -150,6 +156,12 @@ impl IndicatifSpanExt for Span {
     fn pb_reset_eta(&self) {
         apply_to_indicatif_span(self, |indicatif_ctx| {
             indicatif_ctx.reset_progress_bar_eta();
+        });
+    }
+
+    fn pb_set_finish_message(&self, msg: &str) {
+        apply_to_indicatif_span(self, |indicatif_ctx| {
+            indicatif_ctx.set_progress_bar_finish_message(msg.to_string());
         });
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -158,6 +158,53 @@ foo{}
 }
 
 #[test]
+fn test_one_pb_with_finish_message() {
+    let (subscriber, term) = make_helpers(HelpersConfig::default());
+
+    tracing::subscriber::with_default(subscriber, || {
+        let _span = info_span!("foo").entered();
+        _span.pb_set_style(&ProgressStyle::with_template("{span_name} {msg}").unwrap());
+        _span.pb_set_finish_message("done");
+        _span.exit();
+        thread::sleep(Duration::from_millis(10));
+
+        assert_eq!(
+            term.contents(),
+            r#"
+foo done
+            "#
+            .trim()
+        );
+    });
+}
+
+#[test]
+fn test_two_pb_with_finish_messages() {
+    let (subscriber, term) = make_helpers(HelpersConfig::default());
+
+    tracing::subscriber::with_default(subscriber, || {
+        let _span = info_span!("foo").entered();
+        _span.pb_set_style(&ProgressStyle::with_template("{span_name} {msg}").unwrap());
+        _span.pb_set_finish_message("done");
+        _span.exit();
+        let _span2 = info_span!("bar").entered();
+        _span2.pb_set_style(&ProgressStyle::with_template("{span_name} {msg}").unwrap());
+        _span2.pb_set_finish_message("finished");
+        _span2.exit();
+        thread::sleep(Duration::from_millis(10));
+
+        assert_eq!(
+            term.contents(),
+            r#"
+foo done
+bar finished
+            "#
+            .trim()
+        );
+    });
+}
+
+#[test]
 fn test_span_fields() {
     let (subscriber, term) = make_helpers(HelpersConfig::default());
 


### PR DESCRIPTION
Typically progress bars are removed at the end of span. This change allows to keep them present given that user have provided "finish message" by calling `pb_set_finish_message` on the span.